### PR TITLE
Add static inventory dashboard prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # Tools
+
+## Inventory Dashboard Prototype
+
+A lightweight static prototype of the Inventory Health Dashboard. It mirrors the inline HTML snippet that powers the NetSuite-based dashboard so you can preview the experience locally and iterate without connecting to the production backend.
+
+### Project structure
+
+```
+inventory-dashboard/
+├── app.js          # Dashboard logic and rendering helpers
+├── index.html      # Page layout
+├── styles.css      # Visual styling
+└── data/
+    └── sample-data.json  # Example API response used as a local fallback
+```
+
+### Running the prototype
+
+Any static file server can host the dashboard. If you have Python installed, the quickest option is:
+
+```bash
+cd inventory-dashboard
+python -m http.server 8000
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser.
+
+The app will attempt to load data from `/inventory/dashboard`. When that route is unavailable it automatically falls back to the bundled `data/sample-data.json` payload so you can explore the UI offline.
+
+### Customising
+
+* Replace `data/sample-data.json` with a payload generated from your environment. The file shape matches the API contract expected by `app.js`.
+* Update the URLs in `index.html` if your NetSuite account or export routes differ.
+* Adjust styling by editing `styles.css`. The palette and spacing variables are defined at the top of the file.

--- a/inventory-dashboard/app.js
+++ b/inventory-dashboard/app.js
@@ -1,0 +1,183 @@
+const rowTemplate = document.getElementById('rowTemplate');
+const tableBody = document.getElementById('rows');
+const lastUpdated = document.getElementById('lastUpdated');
+const locationSelect = document.getElementById('loc');
+const deltaInput = document.getElementById('thrDelta');
+const dosInput = document.getElementById('thrDos');
+const refreshBtn = document.getElementById('refreshBtn');
+
+const BADGE_VARIANTS = {
+  ok: 'badge--ok',
+  warn: 'badge--warn',
+  err: 'badge--err',
+};
+
+const formatNumber = (value) =>
+  Number.isFinite(value) ? value.toLocaleString(undefined, { maximumFractionDigits: 0 }) : '—';
+
+const makeBadge = (label, variant) => {
+  const span = document.createElement('span');
+  span.className = `badge ${BADGE_VARIANTS[variant] ?? BADGE_VARIANTS.warn}`;
+  span.textContent = label;
+  return span;
+};
+
+const buildLink = (itemId) =>
+  `https://td3012435.app.netsuite.com/app/common/entity/item.nl?id=${encodeURIComponent(itemId)}`;
+
+async function loadData(location = 'all') {
+  const params = new URLSearchParams({ location });
+  const source = `/inventory/dashboard?${params.toString()}`;
+
+  try {
+    const response = await fetch(source, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.warn('Falling back to local sample data', error);
+    const fallback = await fetch('./data/sample-data.json');
+    return fallback.json();
+  }
+}
+
+function renderLocations(locations = []) {
+  locationSelect.innerHTML = '';
+  const defaultOption = document.createElement('option');
+  defaultOption.value = 'all';
+  defaultOption.textContent = 'All Locations';
+  locationSelect.append(defaultOption);
+
+  locations.forEach((loc) => {
+    if (!loc) return;
+    const option = document.createElement('option');
+    option.value = loc;
+    option.textContent = loc;
+    locationSelect.append(option);
+  });
+}
+
+function computeDelta(last30, prior30) {
+  if (prior30 > 0) {
+    return ((last30 - prior30) / prior30) * 100;
+  }
+  return last30 > 0 ? 100 : 0;
+}
+
+function renderRows(rows) {
+  tableBody.innerHTML = '';
+  if (!rows?.length) {
+    const emptyRow = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 7;
+    cell.className = 'table__cell';
+    cell.textContent = 'No items match the selected filters.';
+    emptyRow.append(cell);
+    tableBody.append(emptyRow);
+    return;
+  }
+
+  const deltaThreshold = Number(deltaInput.value) || 30;
+  const dosThreshold = Number(dosInput.value) || 0;
+
+  rows.forEach((row) => {
+    const template = rowTemplate.content.cloneNode(true);
+    const link = template.querySelector('.link');
+    link.href = buildLink(row.itemId);
+    link.textContent = row.itemName ?? 'Item';
+
+    template.querySelector('[data-field="units90"]').textContent = formatNumber(row.units90 ?? 0);
+    template.querySelector('[data-field="last30"]').textContent = formatNumber(row.last30 ?? 0);
+    template.querySelector('[data-field="prior30"]').textContent = formatNumber(row.prior30 ?? 0);
+
+    const delta = computeDelta(row.last30 ?? 0, row.prior30 ?? 0);
+    let deltaLabel = `${delta.toFixed(0)}%`;
+    if ((row.prior30 ?? 0) === 0 && (row.last30 ?? 0) > 0) {
+      deltaLabel = 'new';
+    }
+    template.querySelector('[data-field="delta"]').textContent = deltaLabel;
+
+    const avgDaily = row.avgDaily ?? 0;
+    let dosValue = null;
+    if (avgDaily > 0) {
+      dosValue = (Number(row.onHand ?? 0) + Number(row.onOrder ?? 0)) / avgDaily;
+    }
+
+    const dosCell = template.querySelector('[data-field="dos"]');
+    dosCell.textContent = Number.isFinite(dosValue) ? dosValue.toFixed(1) : '—';
+
+    const alertsCell = template.querySelector('[data-field="alerts"]');
+    alertsCell.className = 'table__cell';
+    const badges = document.createElement('span');
+    badges.className = 'badges';
+
+    const hasSpike = row.prior30 > 0 && delta >= deltaThreshold;
+    const hasDrop = row.prior30 > 0 && delta <= -deltaThreshold;
+    const isNew = (row.prior30 ?? 0) === 0 && (row.last30 ?? 0) > 0;
+
+    if (hasSpike || isNew) {
+      badges.append(makeBadge(isNew ? 'new' : 'spike', 'warn'));
+    }
+    if (hasDrop) {
+      badges.append(makeBadge('drop', 'err'));
+    }
+
+    const leadTime = Number(row.leadTime ?? 0);
+    const reorderPoint = Number(row.reorderPoint ?? 0);
+    const avgDailyDemand = avgDaily || 0;
+    if (Number.isFinite(dosValue)) {
+      const reorderCoverage = avgDailyDemand > 0 ? reorderPoint / avgDailyDemand : null;
+      const isRisk =
+        (dosThreshold > 0 && dosValue < dosThreshold) ||
+        (leadTime > 0 && dosValue < leadTime) ||
+        (reorderCoverage !== null && dosValue < reorderCoverage);
+
+      if (isRisk) {
+        badges.append(makeBadge('coverage risk', 'warn'));
+      } else if (dosValue > leadTime * 3 && leadTime > 0) {
+        badges.append(makeBadge('healthy', 'ok'));
+      }
+    }
+
+    if (badges.children.length === 0) {
+      badges.append(makeBadge('—', 'warn'));
+    }
+
+    alertsCell.append(badges);
+    tableBody.append(template);
+  });
+}
+
+async function refresh() {
+  const location = locationSelect.value || 'all';
+  const data = await loadData(location);
+  if (data.locations) {
+    renderLocations(data.locations);
+    if (location !== 'all') {
+      locationSelect.value = location;
+    }
+  } else if (!locationSelect.options.length) {
+    renderLocations([]);
+  }
+
+  const rows = Array.isArray(data.rows) ? data.rows : [];
+  const hasLocationField = rows.some((row) => Object.prototype.hasOwnProperty.call(row ?? {}, 'location'));
+  const filteredRows =
+    location === 'all' || !hasLocationField
+      ? rows
+      : rows.filter((row) => (row?.location ?? null) === location);
+
+  renderRows(filteredRows);
+  lastUpdated.textContent = data.lastRefreshedAt ?? '—';
+}
+
+refreshBtn.addEventListener('click', () => {
+  refresh();
+});
+
+deltaInput.addEventListener('change', refresh);
+dosInput.addEventListener('change', refresh);
+locationSelect.addEventListener('change', refresh);
+
+refresh();

--- a/inventory-dashboard/data/sample-data.json
+++ b/inventory-dashboard/data/sample-data.json
@@ -1,0 +1,71 @@
+{
+  "lastRefreshedAt": "2024-03-01 08:15",
+  "locations": ["Northeast", "Midwest", "West"],
+  "rows": [
+    {
+      "itemId": 1024,
+      "itemName": "Carbon Steel Bolt 3/8\"",
+      "location": "Northeast",
+      "units90": 1820,
+      "last30": 640,
+      "prior30": 420,
+      "onHand": 320,
+      "onOrder": 180,
+      "leadTime": 7,
+      "reorderPoint": 250,
+      "avgDaily": 18.5
+    },
+    {
+      "itemId": 2048,
+      "itemName": "Hex Nut 3/8\"",
+      "location": "Midwest",
+      "units90": 1510,
+      "last30": 360,
+      "prior30": 520,
+      "onHand": 700,
+      "onOrder": 120,
+      "leadTime": 10,
+      "reorderPoint": 400,
+      "avgDaily": 16.8
+    },
+    {
+      "itemId": 3056,
+      "itemName": "Steel Washer 3/8\"",
+      "location": "West",
+      "units90": 980,
+      "last30": 120,
+      "prior30": 110,
+      "onHand": 95,
+      "onOrder": 20,
+      "leadTime": 12,
+      "reorderPoint": 160,
+      "avgDaily": 4.6
+    },
+    {
+      "itemId": 4072,
+      "itemName": "Anchor Kit",
+      "location": "Northeast",
+      "units90": 650,
+      "last30": 200,
+      "prior30": 80,
+      "onHand": 180,
+      "onOrder": 40,
+      "leadTime": 14,
+      "reorderPoint": 120,
+      "avgDaily": 6.5
+    },
+    {
+      "itemId": 5096,
+      "itemName": "Masonry Drill Bit",
+      "location": "Midwest",
+      "units90": 430,
+      "last30": 30,
+      "prior30": 210,
+      "onHand": 150,
+      "onOrder": 0,
+      "leadTime": 21,
+      "reorderPoint": 80,
+      "avgDaily": 5.2
+    }
+  ]
+}

--- a/inventory-dashboard/index.html
+++ b/inventory-dashboard/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inventory Health Dashboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="inv-canvas" class="canvas">
+      <div class="canvas__inner">
+        <header class="header">
+          <h1 class="header__title">Inventory Health Dashboard</h1>
+          <div class="header__controls">
+            <span class="header__updated">Last Updated: <strong id="lastUpdated"></strong></span>
+            <button type="button" class="btn btn--primary" id="refreshBtn">Refresh</button>
+            <a class="btn btn--secondary" href="/export.csv">Export CSV</a>
+          </div>
+        </header>
+
+        <section class="quick-links" aria-label="Quick links">
+          <a class="quick-links__card quick-links__card--primary" href="https://td3012435.app.netsuite.com/app/reporting/reportrunner.nl?cr=230&whence=" target="_blank" rel="noopener noreferrer">
+            <div class="quick-links__label">Report</div>
+            <div class="quick-links__title">Inventory Valuation Summary</div>
+          </a>
+          <a class="quick-links__card quick-links__card--success" href="https://td3012435.app.netsuite.com/app/reporting/reportrunner.nl?cr=456&whence=" target="_blank" rel="noopener noreferrer">
+            <div class="quick-links__label">Custom Report</div>
+            <div class="quick-links__title">Inventory Turnover (ID: 456)</div>
+          </a>
+        </section>
+
+        <section class="filters" aria-label="Dashboard filters">
+          <label class="filters__field">
+            <span class="filters__label">Location</span>
+            <select id="loc" class="filters__input"></select>
+          </label>
+          <label class="filters__field">
+            <span class="filters__label">Spike/Drop Δ%</span>
+            <input id="thrDelta" class="filters__input filters__input--small" type="number" value="30" min="5" max="95" />
+          </label>
+          <label class="filters__field">
+            <span class="filters__label">Min DoS</span>
+            <input id="thrDos" class="filters__input filters__input--small" type="number" value="0" min="0" max="365" />
+          </label>
+        </section>
+
+        <section class="card" aria-labelledby="itemsHeading">
+          <div class="card__header">
+            <div>
+              <h2 id="itemsHeading" class="card__title">Top Items — Demand, DoS &amp; Alerts</h2>
+              <p class="card__subtitle">Shows last 90d unit sales; Δ% compares last 30d vs prior 30d. DoS = (On-hand + On-order) / Avg daily demand (last 30d).</p>
+            </div>
+          </div>
+          <div class="table-wrapper">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th scope="col">Item</th>
+                  <th scope="col" class="u-text-right">Units Sold (90d)</th>
+                  <th scope="col" class="u-text-right">Last 30d</th>
+                  <th scope="col" class="u-text-right">Prior 30d</th>
+                  <th scope="col">Δ%</th>
+                  <th scope="col" class="u-text-right">DoS</th>
+                  <th scope="col">Alerts</th>
+                </tr>
+              </thead>
+              <tbody id="rows" aria-live="polite"></tbody>
+            </table>
+          </div>
+          <footer class="card__footer">
+            Turnover: use
+            <a href="https://td3012435.app.netsuite.com/app/reporting/reportrunner.nl?cr=230&whence=" target="_blank" rel="noopener noreferrer">Inventory Valuation Summary</a>
+            or custom
+            <a href="https://td3012435.app.netsuite.com/app/reporting/reportrunner.nl?cr=456&whence=" target="_blank" rel="noopener noreferrer">Inventory Turnover (ID 456)</a>.
+            Thresholds configurable above.
+          </footer>
+        </section>
+      </div>
+    </div>
+
+    <template id="rowTemplate">
+      <tr>
+        <td class="table__cell table__cell--item">
+          <a class="link" target="_blank" rel="noopener noreferrer"></a>
+        </td>
+        <td class="table__cell u-text-right" data-field="units90"></td>
+        <td class="table__cell u-text-right" data-field="last30"></td>
+        <td class="table__cell u-text-right" data-field="prior30"></td>
+        <td class="table__cell" data-field="delta"></td>
+        <td class="table__cell u-text-right" data-field="dos"></td>
+        <td class="table__cell" data-field="alerts"></td>
+      </tr>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/inventory-dashboard/styles.css
+++ b/inventory-dashboard/styles.css
@@ -1,0 +1,280 @@
+:root {
+  color-scheme: only light;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --color-bg: #f1efed;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f5fafc;
+  --color-border: #e7f2f5;
+  --color-text: #13212c;
+  --color-text-muted: #264759;
+  --color-primary: #36677d;
+  --color-secondary: #94bfce;
+  --color-success: #86b596;
+  --color-warning: #e2c06b;
+  --color-error: #ff8675;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.canvas {
+  padding: 2rem;
+  min-height: 100vh;
+}
+
+.canvas__inner {
+  margin: 0 auto;
+  max-width: 1200px;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.header__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.header__controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.header__updated {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 6px;
+  border: none;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 2px;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.btn--secondary {
+  background: var(--color-secondary);
+  color: #fff;
+}
+
+.quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.quick-links__card {
+  display: block;
+  padding: 1rem;
+  border-radius: 8px;
+  color: #fff;
+  text-decoration: none;
+  box-shadow: 0 1px 3px rgba(19, 33, 44, 0.1);
+}
+
+.quick-links__card--primary {
+  background: var(--color-primary);
+}
+
+.quick-links__card--success {
+  background: var(--color-success);
+}
+
+.quick-links__label {
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.quick-links__title {
+  font-weight: 600;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  color: var(--color-text-muted);
+}
+
+.filters__field {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.filters__label {
+  font-weight: 500;
+}
+
+.filters__input {
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.35rem 0.5rem;
+  background: #fff;
+  font: inherit;
+  color: var(--color-text-muted);
+}
+
+.filters__input--small {
+  width: 4rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(19, 33, 44, 0.1);
+  overflow: hidden;
+}
+
+.card__header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card__title {
+  margin: 0;
+}
+
+.card__subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.table thead th {
+  background: var(--color-surface-alt);
+  text-align: left;
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.table__cell {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  vertical-align: middle;
+}
+
+.table__cell--item .link {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.table__cell--item .link:hover,
+.table__cell--item .link:focus {
+  text-decoration: underline;
+}
+
+.badges {
+  display: inline-flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.badge--ok {
+  background: var(--color-success);
+  color: #fff;
+}
+
+.badge--warn {
+  background: var(--color-warning);
+  color: var(--color-text);
+}
+
+.badge--err {
+  background: var(--color-error);
+  color: #fff;
+}
+
+.card__footer {
+  padding: 0.75rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.card__footer a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.card__footer a:hover,
+.card__footer a:focus {
+  text-decoration: underline;
+}
+
+.u-text-right {
+  text-align: right;
+}
+
+@media (max-width: 600px) {
+  .canvas {
+    padding: 1.25rem;
+  }
+
+  .table {
+    min-width: 560px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone HTML layout for the Inventory Health Dashboard with reusable template markup
- implement dashboard rendering logic with badge rules and data fallbacks plus sample data
- document the prototype structure and local hosting instructions in the README

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68ed535031d883268491403e454a7ec6